### PR TITLE
Refactor play page into multiple components

### DIFF
--- a/components/play/GameBoard.tsx
+++ b/components/play/GameBoard.tsx
@@ -1,0 +1,111 @@
+import Square from "@/components/Square";
+import ConfettiBurst, { type ConfettiParticle } from "@/components/ConfettiBurst";
+
+export type Position = { row: number; col: number };
+
+interface GameBoardProps {
+  boardSize: number;
+  cellSize: number;
+  visited: number[][];
+  knightPos: Position | null;
+  showingSolution: boolean;
+  solution?: number[][];
+  solutionStep: number;
+  validMoves: Position[];
+  showVictory: boolean;
+  showFailure: boolean;
+  confetti: boolean;
+  confettiParticles: ConfettiParticle[];
+  onSquareClick: (row: number, col: number) => void;
+}
+
+export default function GameBoard({
+  boardSize,
+  cellSize,
+  visited,
+  knightPos,
+  showingSolution,
+  solution,
+  solutionStep,
+  validMoves,
+  showVictory,
+  showFailure,
+  confetti,
+  confettiParticles,
+  onSquareClick,
+}: GameBoardProps) {
+  return (
+    <div
+      className="relative shadow-2xl rounded-3xl border-[2.5px] border-[#a593c7] bg-[#f5f2fa] flex justify-center items-center"
+      style={{
+        padding: 22,
+        margin: 8,
+        minWidth: boardSize * (cellSize + 8),
+        minHeight: boardSize * (cellSize + 8),
+        position: "relative",
+      }}
+    >
+      <div
+        className="grid"
+        style={{
+          gridTemplateColumns: `repeat(${boardSize}, ${cellSize}px)`,
+          gridTemplateRows: `repeat(${boardSize}, ${cellSize}px)`,
+          gap: "8px",
+          zIndex: 1,
+        }}
+      >
+        {Array.from({ length: boardSize }).map((_, row) =>
+          Array.from({ length: boardSize }).map((_, col) => {
+            let isKnight, moveNum, isVisited;
+            if (showingSolution && solution) {
+              const num = solution[row][col];
+              moveNum = num <= solutionStep ? num : 0;
+              isVisited = moveNum > 0;
+              isKnight = moveNum === solutionStep;
+            } else {
+              isKnight = knightPos?.row === row && knightPos?.col === col;
+              moveNum = visited[row][col];
+              isVisited = moveNum > 0;
+            }
+            const isValidMove =
+              !showingSolution &&
+              !showVictory &&
+              !showFailure &&
+              validMoves.some((pos) => pos.row === row && pos.col === col);
+            let cellEffect = "";
+            if (showVictory && isVisited) cellEffect = "animate-[victorypop_0.4s]";
+            if (showFailure && !isVisited) cellEffect = "animate-[failshake_0.4s]";
+            return (
+              <Square
+                key={`${row}-${col}`}
+                isKnight={isKnight}
+                moveNum={moveNum}
+                isVisited={isVisited}
+                isValidMove={isValidMove}
+                cellEffect={cellEffect}
+                onClick={() => onSquareClick(row, col)}
+                disabled={
+                  (isVisited && !isKnight) ||
+                  showVictory ||
+                  showFailure ||
+                  showingSolution
+                }
+              />
+            );
+          })
+        )}
+        {confetti && <ConfettiBurst particles={confettiParticles} />}
+        {showVictory && (
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-40">
+            <span className="text-6xl animate-winpop">🎉</span>
+          </div>
+        )}
+        {showFailure && (
+          <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-40">
+            <span className="text-5xl animate-failshake text-[#635AA3]">😔</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/play/GameControls.tsx
+++ b/components/play/GameControls.tsx
@@ -1,0 +1,74 @@
+import { useRouter } from "next/navigation";
+
+interface GameControlsProps {
+  boardSize: number;
+  undoDisabled: boolean;
+  redoDisabled: boolean;
+  showingSolution: boolean;
+  showVictory: boolean;
+  showFailure: boolean;
+  onUndo: () => void;
+  onRedo: () => void;
+  onShowSolution: () => void;
+  onReset: () => void;
+}
+
+export default function GameControls({
+  boardSize,
+  undoDisabled,
+  redoDisabled,
+  showingSolution,
+  showVictory,
+  showFailure,
+  onUndo,
+  onRedo,
+  onShowSolution,
+  onReset,
+}: GameControlsProps) {
+  const router = useRouter();
+  return (
+    <div className="flex flex-wrap justify-center gap-3 mb-1">
+      <button
+        className="text-[#635AA3] hover:underline font-semibold"
+        onClick={() => router.push("/")}
+      >
+        Home
+      </button>
+      <button
+        className={`text-[#635AA3] font-semibold hover:underline ${
+          undoDisabled ? "opacity-40 cursor-not-allowed" : ""
+        }`}
+        onClick={onUndo}
+        disabled={undoDisabled || showingSolution || showVictory || showFailure}
+        title="Undo"
+      >
+        Undo
+      </button>
+      <button
+        className={`text-[#635AA3] font-semibold hover:underline ${
+          redoDisabled ? "opacity-40 cursor-not-allowed" : ""
+        }`}
+        onClick={onRedo}
+        disabled={redoDisabled || showingSolution || showVictory || showFailure}
+        title="Redo"
+      >
+        Redo
+      </button>
+      {boardSize === 5 && (
+        <button
+          className="text-[#635AA3] hover:underline font-semibold"
+          disabled={showingSolution}
+          onClick={onShowSolution}
+        >
+          Show Solution
+        </button>
+      )}
+      <button
+        className="text-[#DAAB79] hover:underline font-semibold"
+        onClick={onReset}
+      >
+        Reset
+      </button>
+    </div>
+  );
+}

--- a/components/play/GameInfo.tsx
+++ b/components/play/GameInfo.tsx
@@ -1,0 +1,35 @@
+interface GameInfoProps {
+  showVictory: boolean;
+  showFailure: boolean;
+  gameStarted: boolean;
+  moveCount: number;
+  boardSize: number;
+}
+
+export default function GameInfo({
+  showVictory,
+  showFailure,
+  gameStarted,
+  moveCount,
+  boardSize,
+}: GameInfoProps) {
+  return (
+    <div className="mt-3 text-lg text-black font-semibold min-h-[32px]">
+      {showVictory ? (
+        <span className="text-green-600 animate-pulse">
+          🎉 You completed the Knight's Tour!
+        </span>
+      ) : showFailure ? (
+        <span className="text-[#635AA3] animate-failshake">
+          No more moves! Try again.
+        </span>
+      ) : !gameStarted ? (
+        <>Click any square to start!</>
+      ) : (
+        <>
+          Move: <span className="font-bold">{moveCount}</span> / {boardSize * boardSize}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- split play page into smaller components
  - add GameBoard, GameControls, and GameInfo components
  - simplify `app/play/[size]/page.tsx` to use these components

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859399e6af08331992eee1b15f2524c