### PR TITLE
Improve board visibility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,11 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --primary: #635AA3;
+  --secondary: #DAAB79;
+  --surface: #faf8ff;
+  --board-bg: #e0dcff;
+  --square-bg: #f7f5ff;
 }
 
 @theme inline {
@@ -16,11 +21,14 @@
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    --surface: #1a1a1a;
+    --board-bg: #202023;
+    --square-bg: #2e2f33;
   }
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans), Arial, Helvetica, sans-serif;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import React, { type ReactNode } from "react";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
@@ -20,7 +21,7 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <html lang="en">

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -22,11 +22,11 @@ export default function LeaderboardPage() {
   }, []);
 
   return (
-    <main className="flex min-h-screen flex-col items-center bg-[#f7f5fa] text-black">
-      <h1 className="text-4xl font-bold mt-10 mb-6 text-[#635AA3]">
+    <main className="flex min-h-screen flex-col items-center bg-gradient-to-br from-[var(--surface)] to-white text-black">
+      <h1 className="text-4xl font-bold mt-10 mb-6 text-[--primary]">
         🏆 Leaderboard
       </h1>
-      <div className="bg-white rounded-2xl shadow-md p-8 w-full max-w-2xl">
+      <div className="bg-white/90 rounded-2xl border border-[color:var(--primary)/0.2] shadow-lg p-8 w-full max-w-2xl">
         <table className="w-full text-lg">
           <thead>
             <tr className="text-left border-b">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import React, { useState } from "react";
 
 const BOARD_SIZES = [5, 6, 7, 8];
 
@@ -15,13 +15,13 @@ export default function HomePage() {
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-gray-100">
-      <h1 className="text-4xl font-bold mb-8 text-[#635AA3]">
+    <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-[var(--surface)] to-white">
+      <h1 className="text-4xl font-bold mb-8 text-[--primary]">
         Knight's Tour Challenge
       </h1>
       <form
         onSubmit={handleSubmit}
-        className="bg-white rounded-2xl shadow-md p-8 flex flex-col items-center gap-4"
+        className="bg-white/90 rounded-2xl border border-[color:var(--primary)/0.2] shadow-lg p-8 flex flex-col items-center gap-4"
       >
         <label htmlFor="size" className="font-medium text-lg text-black">
           Choose Board Size:
@@ -40,7 +40,7 @@ export default function HomePage() {
         </select>
         <button
           type="submit"
-          className="bg-[#635AA3] text-white px-8 py-2 rounded-xl font-semibold mt-4 hover:bg-[#4b437b] transition"
+          className="bg-[--primary] text-white px-8 py-2 rounded-xl font-semibold shadow mt-4 hover:brightness-110 transition"
         >
           Start Game
         </button>

--- a/app/play/[size]/page.tsx
+++ b/app/play/[size]/page.tsx
@@ -61,12 +61,12 @@ export default function PlayPage() {
   }
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-[#e4dbe8] via-[#faf7ef] to-[#dfd2c2] flex flex-col items-center py-0">
+    <main className="min-h-screen bg-gradient-to-br from-[var(--surface)] to-white flex flex-col items-center py-0">
       {/* Header / Banner */}
 
-      <div className="relative w-full flex flex-col items-center bg-[#635AA3] text-white py-6 shadow-md mb-8 rounded-b-3xl">
+      <div className="relative w-full flex flex-col items-center bg-[--primary] text-white py-6 shadow-md mb-8 rounded-b-3xl">
         <div className="text-center flex flex-col items-center gap-1">
-          <span className="font-bold text-2xl sm:text-4xl tracking-tight text-[#DAAB79] drop-shadow-xl">
+          <span className="font-bold text-2xl sm:text-4xl tracking-tight text-[--secondary] drop-shadow-xl">
             ♞ Knight's Tour Challenge
           </span>
           <span className="mt-1 text-base sm:text-lg opacity-85 font-medium">
@@ -75,14 +75,14 @@ export default function PlayPage() {
         </div>
         <Link
           href="/leaderboard"
-          className="absolute right-6 top-1/2 -translate-y-1/2 bg-[#DAAB79] text-[#1a191f] font-semibold px-5 py-2 rounded-xl shadow hover:bg-[#fff1d1] hover:text-[#483776] transition text-base sm:text-lg border-2 border-[#e8e2d2]"
+          className="absolute right-6 top-1/2 -translate-y-1/2 bg-[--secondary] text-[#1a191f] font-semibold px-5 py-2 rounded-xl shadow hover:brightness-110 transition text-base sm:text-lg"
           style={{ minWidth: 140, textAlign: "center" }}
         >
           🏆 Leaderboard
         </Link>
       </div>
 
-      <div className="flex flex-col items-center bg-white/95 rounded-3xl shadow-2xl p-6 sm:p-12 mt-2 max-w-fit border-[#e8e2d2] border-[2.5px]">
+      <div className="flex flex-col items-center bg-white/95 rounded-3xl shadow-2xl p-6 sm:p-12 mt-2 max-w-fit border-[color:var(--primary)/0.2] border-[2.5px]">
         <GameControls
           boardSize={boardSize}
           undoDisabled={undoDisabled}

--- a/components/Square.tsx
+++ b/components/Square.tsx
@@ -20,17 +20,17 @@ export default function Square({
   disabled,
 }: SquareProps) {
   const squareColor = isKnight
-    ? "bg-[#635AA3] shadow-2xl"
+    ? "bg-[--primary] shadow-2xl"
     : isVisited
-    ? "bg-[#DAAB79]/90"
-    : "bg-[#faf8ff]";
+    ? "bg-[color:var(--secondary)/0.9]"
+    : "bg-[--square-bg]";
 
   return (
     <button
       className={`
-        relative w-[85px] h-[85px] rounded-xl border border-[#d8d1e7]/70 overflow-hidden
+        relative w-[85px] h-[85px] rounded-xl border border-[color:var(--primary)/0.3] overflow-hidden
         flex flex-col items-center justify-center transition-all
-        ${isValidMove ? "ring-2 ring-[#635AA3]/80 z-10" : ""}
+        ${isValidMove ? "ring-2 ring-[color:var(--primary)/0.8] z-10" : ""}
         ${squareColor}
         ${cellEffect}
       `}

--- a/components/play/GameBoard.tsx
+++ b/components/play/GameBoard.tsx
@@ -36,7 +36,7 @@ export default function GameBoard({
 }: GameBoardProps) {
   return (
     <div
-      className="relative shadow-2xl rounded-3xl border-[2.5px] border-[#a593c7] bg-[#f5f2fa] flex justify-center items-center"
+      className="relative shadow-2xl rounded-3xl border-[2.5px] border-[color:var(--primary)/0.3] bg-[--board-bg] flex justify-center items-center"
       style={{
         padding: 22,
         margin: 8,
@@ -102,7 +102,7 @@ export default function GameBoard({
         )}
         {showFailure && (
           <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-40">
-            <span className="text-5xl animate-failshake text-[#635AA3]">😔</span>
+            <span className="text-5xl animate-failshake text-[--primary]">😔</span>
           </div>
         )}
       </div>

--- a/components/play/GameControls.tsx
+++ b/components/play/GameControls.tsx
@@ -29,13 +29,13 @@ export default function GameControls({
   return (
     <div className="flex flex-wrap justify-center gap-3 mb-1">
       <button
-        className="text-[#635AA3] hover:underline font-semibold"
+        className="px-4 py-1 rounded-md bg-[--primary] text-white font-semibold shadow hover:brightness-110"
         onClick={() => router.push("/")}
       >
         Home
       </button>
       <button
-        className={`text-[#635AA3] font-semibold hover:underline ${
+        className={`px-4 py-1 rounded-md bg-[--primary] text-white font-semibold shadow hover:brightness-110 ${
           undoDisabled ? "opacity-40 cursor-not-allowed" : ""
         }`}
         onClick={onUndo}
@@ -45,7 +45,7 @@ export default function GameControls({
         Undo
       </button>
       <button
-        className={`text-[#635AA3] font-semibold hover:underline ${
+        className={`px-4 py-1 rounded-md bg-[--primary] text-white font-semibold shadow hover:brightness-110 ${
           redoDisabled ? "opacity-40 cursor-not-allowed" : ""
         }`}
         onClick={onRedo}
@@ -56,7 +56,7 @@ export default function GameControls({
       </button>
       {boardSize === 5 && (
         <button
-          className="text-[#635AA3] hover:underline font-semibold"
+          className="px-4 py-1 rounded-md bg-[--primary] text-white font-semibold shadow hover:brightness-110"
           disabled={showingSolution}
           onClick={onShowSolution}
         >
@@ -64,7 +64,7 @@ export default function GameControls({
         </button>
       )}
       <button
-        className="text-[#DAAB79] hover:underline font-semibold"
+        className="px-4 py-1 rounded-md bg-[--secondary] text-[#1a191f] font-semibold shadow hover:brightness-110"
         onClick={onReset}
       >
         Reset

--- a/components/play/GameInfo.tsx
+++ b/components/play/GameInfo.tsx
@@ -29,7 +29,7 @@ export default function GameInfo({
           🎉 You completed the Knight's Tour!
         </span>
       ) : showFailure ? (
-        <span className="text-[#635AA3] animate-failshake">
+        <span className="text-[--primary] animate-failshake">
           No more moves! Try again.
         </span>
       ) : !gameStarted ? (

--- a/components/play/UserNamePrompt.tsx
+++ b/components/play/UserNamePrompt.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import React, { useState } from "react";
 import { registerGuestUser } from "@/utils/guestUser";
 
 export default function UserNamePrompt({
@@ -34,7 +34,7 @@ export default function UserNamePrompt({
           autoFocus
         />
         <button
-          className="bg-[#635AA3] text-white py-2 rounded font-semibold hover:bg-[#524690]"
+          className="bg-[--primary] text-white py-2 rounded font-semibold shadow hover:brightness-110"
           disabled={loading}
         >
           {loading ? "Registering..." : "Start Playing"}

--- a/hooks/useKnightsTour.ts
+++ b/hooks/useKnightsTour.ts
@@ -66,7 +66,7 @@ export function useKnightsTour(boardSize: number, user: User | null) {
   const [showFailure, setShowFailure] = useState(false);
 
   const [knightAnim, setKnightAnim] = useState<{ row: number; col: number } | null>(null);
-  const animTimeout = useRef<NodeJS.Timeout | null>(null);
+  const animTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [confetti, setConfetti] = useState(false);
   const [confettiParticles, setConfettiParticles] = useState<ConfettiParticle[]>([]);

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -2,5 +2,5 @@ import { createClient } from '@supabase/supabase-js';
 
 export const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
 );

--- a/utils/guestUser.ts
+++ b/utils/guestUser.ts
@@ -1,10 +1,10 @@
 import { v4 as uuidv4 } from "uuid";
 import { supabase } from "@/lib/supabase";
 
-export async function registerGuestUser(name: string) {
+export async function registerGuestUser(name: string): Promise<{ user_id: string; username: string }> {
   // Check localStorage first
-  let user_id = localStorage.getItem("guest_user_id");
-  let username = localStorage.getItem("guest_user_name");
+  let user_id: string | null = localStorage.getItem("guest_user_id");
+  const username = localStorage.getItem("guest_user_name");
 
   if (user_id && username) {
     // Optionally verify with DB here


### PR DESCRIPTION
## Summary
- tweak board and square color variables for better contrast
- style GameBoard and Square using new CSS variables
- update buttons to use CSS vars and add shadows for visibility

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a7eee26ec8331b76cd1d11ef36230