### PR TITLE
Update color theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,11 +1,11 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
-  --primary: #635AA3;
-  --secondary: #DAAB79;
-  --surface: #faf8ff;
+  --background: #0f172a;
+  --foreground: #e2e8f0;
+  --primary: #8b5cf6;
+  --secondary: #fbbf24;
+  --surface: #1e293b;
 }
 
 @theme inline {
@@ -18,8 +18,8 @@
 @media (prefers-color-scheme: dark) {
   :root {
     --background: #0a0a0a;
-    --foreground: #ededed;
-    --surface: #1a1a1a;
+    --foreground: #f8fafc;
+    --surface: #111827;
   }
 }
 

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -22,7 +22,7 @@ export default function LeaderboardPage() {
   }, []);
 
   return (
-    <main className="flex min-h-screen flex-col items-center bg-gradient-to-br from-[var(--surface)] to-white text-black">
+    <main className="flex min-h-screen flex-col items-center bg-gradient-to-br from-[var(--surface)] to-[var(--background)] text-[var(--foreground)]">
       <h1 className="text-4xl font-bold mt-10 mb-6 text-[var(--primary)]">
         🏆 Leaderboard
       </h1>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ export default function HomePage() {
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-[var(--surface)] to-white">
+    <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-[var(--surface)] to-[var(--background)] text-[var(--foreground)]">
       <h1 className="text-4xl font-bold mb-8 text-[var(--primary)]">
         Knight's Tour Challenge
       </h1>

--- a/app/play/[size]/page.tsx
+++ b/app/play/[size]/page.tsx
@@ -61,7 +61,7 @@ export default function PlayPage() {
   }
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-[var(--surface)] to-white flex flex-col items-center py-0">
+    <main className="min-h-screen bg-gradient-to-br from-[var(--surface)] to-[var(--background)] flex flex-col items-center py-0">
       {/* Header / Banner */}
 
       <div className="relative w-full flex flex-col items-center bg-[var(--primary)] text-white py-6 shadow-md mb-8 rounded-b-3xl">
@@ -75,7 +75,7 @@ export default function PlayPage() {
         </div>
         <Link
           href="/leaderboard"
-          className="absolute right-6 top-1/2 -translate-y-1/2 bg-[var(--secondary)] text-[#1a191f] font-semibold px-5 py-2 rounded-xl shadow hover:brightness-110 transition text-base sm:text-lg"
+          className="absolute right-6 top-1/2 -translate-y-1/2 bg-[var(--secondary)] text-[var(--background)] font-semibold px-5 py-2 rounded-xl shadow hover:brightness-110 transition text-base sm:text-lg"
           style={{ minWidth: 140, textAlign: "center" }}
         >
           🏆 Leaderboard
@@ -124,8 +124,8 @@ export default function PlayPage() {
       <style>
         {`
         @keyframes victorypop {
-          0% { transform: scale(0.8) rotate(-8deg); background: #ffe19f; }
-          50% { transform: scale(1.12) rotate(6deg); background: #e1ffd4; }
+          0% { transform: scale(0.8) rotate(-8deg); background: #fbbf24; }
+          50% { transform: scale(1.12) rotate(6deg); background: #86efac; }
           100% { transform: scale(1) rotate(0);}
         }
         .animate-[victorypop_0.4s] { animation: victorypop 0.38s; }
@@ -144,8 +144,8 @@ export default function PlayPage() {
         }
         .animate-winpop { animation: winpop 1.18s;}
         @keyframes hopknight {
-          0% { transform: translateY(0) scale(1); filter: drop-shadow(0 1px 16px #b9a6f9aa);}
-          32% { transform: translateY(-18px) scale(1.12); filter: drop-shadow(0 8px 22px #7267c6);}
+          0% { transform: translateY(0) scale(1); filter: drop-shadow(0 1px 16px #c084fcaa);}
+          32% { transform: translateY(-18px) scale(1.12); filter: drop-shadow(0 8px 22px #7c3aed);}
           80% { transform: translateY(1px) scale(1.04);}
           100% { transform: translateY(0) scale(1);}
         }

--- a/components/Square.tsx
+++ b/components/Square.tsx
@@ -36,7 +36,7 @@ export default function Square({
       `}
       style={{
         transition: "background 0.18s, box-shadow 0.16s, transform 0.18s",
-        boxShadow: isKnight ? "0 8px 36px #635aa347" : "",
+        boxShadow: isKnight ? "0 8px 36px #8b5cf647" : "",
       }}
       tabIndex={0}
       onClick={onClick}
@@ -45,12 +45,12 @@ export default function Square({
       {isKnight ? (
         <span className="flex flex-col items-center justify-center z-30 animate-hopknight pointer-events-none select-none">
           <span className="text-white text-4xl drop-shadow-2xl leading-none">♞</span>
-          <span className="text-[#fcbf49] text-lg font-extrabold -mt-1 drop-shadow-md leading-none">
+          <span className="text-[var(--secondary)] text-lg font-extrabold -mt-1 drop-shadow-md leading-none">
             {moveNum}
           </span>
         </span>
       ) : isVisited ? (
-        <span className="text-[#42310b] text-lg font-bold select-none">{moveNum}</span>
+        <span className="text-[var(--background)] text-lg font-bold select-none">{moveNum}</span>
       ) : null}
     </button>
   );

--- a/components/play/GameControls.tsx
+++ b/components/play/GameControls.tsx
@@ -64,7 +64,7 @@ export default function GameControls({
         </button>
       )}
       <button
-        className="px-4 py-1 rounded-md bg-[var(--secondary)] text-[#1a191f] font-semibold hover:brightness-110"
+        className="px-4 py-1 rounded-md bg-[var(--secondary)] text-[var(--background)] font-semibold hover:brightness-110"
         onClick={onReset}
       >
         Reset

--- a/hooks/useKnightsTour.ts
+++ b/hooks/useKnightsTour.ts
@@ -18,14 +18,14 @@ export const SOLUTIONS: Record<number, number[][]> = {
 };
 
 const CONFETTI_COLORS = [
-  "#635AA3",
-  "#DAAB79",
-  "#fff",
-  "#8d88be",
-  "#e9798c",
-  "#4CC9F0",
-  "#fcbf49",
-  "#4895ef",
+  "#8b5cf6",
+  "#fbbf24",
+  "#ffffff",
+  "#4f46e5",
+  "#f472b6",
+  "#22d3ee",
+  "#4ade80",
+  "#64748b",
 ];
 
 function getKnightMoves(pos: Position, boardSize: number): Position[] {


### PR DESCRIPTION
## Summary
- restyle app with darker game-like palette
- use new colors in page gradients and scoreboard
- tweak square piece colors and confetti

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8ef95d8483318ad49dee089e5e56