### PR TITLE
Add soft pastel theme and improved animations

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,30 +1,24 @@
 @import "tailwindcss";
 
 :root {
-
-  --background: #0f172a;
-  --foreground: #e2e8f0;
-  --primary: #8b5cf6;
-  --secondary: #fbbf24;
-  --surface: #1e293b;
-
+  --background: #E8F2FF;
+  --foreground: #2B2B2B;
+  --primary: #C8F0E6;
+  --secondary: #E9E5FF;
+  --surface: #F4F5F7;
+  --board-light: #F4F5F7;
+  --board-dark: #E8F2FF;
+  --success: #FFE3C4;
+  --error: #FFD8DC;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #f8fafc;
-    --surface: #111827;
-
-  }
-}
 
 body {
   background: var(--background);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,15 +1,16 @@
 import React, { type ReactNode } from "react";
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Poppins, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const poppins = Poppins({
+  variable: "--font-sans",
   subsets: ["latin"],
+  weight: ["400", "700"],
 });
 
 const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+  variable: "--font-mono",
   subsets: ["latin"],
 });
 
@@ -25,9 +26,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${poppins.variable} ${geistMono.variable} antialiased`}>
         {children}
       </body>
     </html>

--- a/app/play/[size]/page.tsx
+++ b/app/play/[size]/page.tsx
@@ -124,9 +124,9 @@ export default function PlayPage() {
       <style>
         {`
         @keyframes victorypop {
-          0% { transform: scale(0.8) rotate(-8deg); background: #fbbf24; }
-          50% { transform: scale(1.12) rotate(6deg); background: #86efac; }
-          100% { transform: scale(1) rotate(0);}
+          0% { transform: scale(0.8) rotate(-8deg); background: var(--success); }
+          50% { transform: scale(1.12) rotate(6deg); background: var(--primary); }
+          100% { transform: scale(1) rotate(0); }
         }
         .animate-[victorypop_0.4s] { animation: victorypop 0.38s; }
         @keyframes failshake {
@@ -136,6 +136,16 @@ export default function PlayPage() {
           40%, 60% { transform: translateX(4px); }
         }
         .animate-[failshake_0.4s], .animate-failshake { animation: failshake 0.38s; }
+        @keyframes highlight {
+          from { box-shadow: 0 0 0 0 var(--primary); }
+          to { box-shadow: 0 0 0 8px transparent; }
+        }
+        .animate-highlight { animation: highlight 0.3s ease-out; }
+        @keyframes fadeOverlay {
+          from { opacity: 0; }
+          to { opacity: 1; }
+        }
+        .animate-fade { animation: fadeOverlay 0.4s ease-out; }
         @keyframes winpop {
           0%   { transform: scale(0.5) rotate(-14deg);}
           45%  { transform: scale(1.2) rotate(13deg);}

--- a/components/Square.tsx
+++ b/components/Square.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 interface SquareProps {
+  row: number;
+  col: number;
   isKnight: boolean;
   moveNum: number;
   isVisited: boolean;
@@ -11,6 +13,8 @@ interface SquareProps {
 }
 
 export default function Square({
+  row,
+  col,
   isKnight,
   moveNum,
   isVisited,
@@ -19,24 +23,31 @@ export default function Square({
   onClick,
   disabled,
 }: SquareProps) {
+  const baseColor =
+    (row + col) % 2 === 0
+      ? "bg-[var(--board-light)]"
+      : "bg-[var(--board-dark)]";
   const squareColor = isKnight
-    ? "bg-[var(--primary)] shadow-2xl"
+    ? "bg-[var(--primary)] shadow-md"
     : isVisited
-    ? "bg-[var(--secondary)]/90"
-    : "bg-[var(--surface)]";
+    ? "bg-[var(--secondary)]"
+    : baseColor;
 
   return (
     <button
       className={`
         relative w-[85px] h-[85px] rounded-xl border border-[var(--primary)]/30 overflow-hidden
-        flex flex-col items-center justify-center transition-all
-        ${isValidMove ? "ring-2 ring-[var(--primary)]/80 z-10" : ""}
+        flex flex-col items-center justify-center transition-all hover:scale-[1.04]
+        before:absolute before:inset-0 before:rounded-[inherit] before:pointer-events-none before:shadow-[inset_0_0_4px_rgba(255,255,255,0.5)]
+        ${isValidMove ? "ring-2 ring-[var(--primary)]/80 z-10 animate-highlight" : ""}
         ${squareColor}
         ${cellEffect}
       `}
       style={{
         transition: "background 0.18s, box-shadow 0.16s, transform 0.18s",
-        boxShadow: isKnight ? "0 8px 36px #8b5cf647" : "",
+        boxShadow: isKnight
+          ? "0 8px 20px rgba(0,0,0,0.15)"
+          : "0 4px 4px rgba(0,0,0,0.1)",
       }}
       tabIndex={0}
       onClick={onClick}

--- a/components/play/GameBoard.tsx
+++ b/components/play/GameBoard.tsx
@@ -38,7 +38,7 @@ export default function GameBoard({
 }: GameBoardProps) {
   return (
     <div
-      className="relative shadow-2xl rounded-3xl border-[2.5px] border-[var(--primary)]/30 bg-[var(--surface)] flex justify-center items-center"
+      className="relative shadow-lg rounded-3xl border-[2.5px] border-[var(--primary)]/30 bg-[var(--surface)] flex justify-center items-center"
       style={{
         padding: 22,
         margin: 8,
@@ -82,6 +82,8 @@ export default function GameBoard({
             return (
               <Square
                 key={`${row}-${col}`}
+                row={row}
+                col={col}
                 isKnight={isKnight}
                 moveNum={moveNum}
                 isVisited={isVisited}
@@ -100,16 +102,20 @@ export default function GameBoard({
         )}
         {confetti && <ConfettiBurst particles={confettiParticles} />}
         {showVictory && (
-          <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-40">
-            <span className="text-6xl animate-winpop">🎉</span>
-          </div>
+          <>
+            <div className="absolute inset-0 bg-[var(--success)]/85 rounded-2xl pointer-events-none z-30 animate-fade" />
+            <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-40">
+              <span className="text-6xl animate-winpop">🎉</span>
+            </div>
+          </>
         )}
         {showFailure && (
-          <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-40">
-            <span className="text-5xl animate-failshake text-[var(--primary)]">
-              😔
-            </span>
-          </div>
+          <>
+            <div className="absolute inset-0 bg-[var(--error)]/85 rounded-2xl pointer-events-none z-30 animate-fade" />
+            <div className="absolute inset-0 flex items-center justify-center pointer-events-none z-40">
+              <span className="text-5xl animate-failshake text-[var(--primary)]">😔</span>
+            </div>
+          </>
         )}
       </div>
     </div>

--- a/components/play/GameControls.tsx
+++ b/components/play/GameControls.tsx
@@ -29,13 +29,13 @@ export default function GameControls({
   return (
     <div className="flex flex-wrap justify-center gap-3 mb-1">
       <button
-        className="px-4 py-1 rounded-md bg-[var(--primary)] text-white font-semibold hover:brightness-110"
+        className="px-4 py-1 rounded-md bg-[var(--primary)] text-[var(--foreground)] font-semibold hover:brightness-110 shadow"
         onClick={() => router.push("/")}
       >
         Home
       </button>
       <button
-        className={`px-4 py-1 rounded-md bg-[var(--primary)] text-white font-semibold hover:brightness-110 ${
+        className={`px-4 py-1 rounded-md bg-[var(--primary)] text-[var(--foreground)] font-semibold hover:brightness-110 shadow ${
           undoDisabled ? "opacity-40 cursor-not-allowed" : ""
         }`}
         onClick={onUndo}
@@ -45,7 +45,7 @@ export default function GameControls({
         Undo
       </button>
       <button
-        className={`px-4 py-1 rounded-md bg-[var(--primary)] text-white font-semibold hover:brightness-110 ${
+        className={`px-4 py-1 rounded-md bg-[var(--primary)] text-[var(--foreground)] font-semibold hover:brightness-110 shadow ${
           redoDisabled ? "opacity-40 cursor-not-allowed" : ""
         }`}
         onClick={onRedo}
@@ -56,7 +56,7 @@ export default function GameControls({
       </button>
       {boardSize === 5 && (
         <button
-          className="px-4 py-1 rounded-md bg-[var(--primary)] text-white font-semibold hover:brightness-110"
+          className="px-4 py-1 rounded-md bg-[var(--primary)] text-[var(--foreground)] font-semibold hover:brightness-110 shadow"
           disabled={showingSolution}
           onClick={onShowSolution}
         >
@@ -64,7 +64,7 @@ export default function GameControls({
         </button>
       )}
       <button
-        className="px-4 py-1 rounded-md bg-[var(--secondary)] text-[var(--background)] font-semibold hover:brightness-110"
+        className="px-4 py-1 rounded-md bg-[var(--secondary)] text-[var(--foreground)] font-semibold hover:brightness-110 shadow"
         onClick={onReset}
       >
         Reset

--- a/components/play/GameInfo.tsx
+++ b/components/play/GameInfo.tsx
@@ -19,17 +19,17 @@ export default function GameInfo({
   user,
 }: GameInfoProps) {
   return (
-    <div className="mt-3 text-lg text-black font-semibold min-h-[32px] flex flex-col gap-1 items-center">
+    <div className="mt-3 text-lg text-[var(--foreground)] font-semibold min-h-[32px] flex flex-col gap-1 items-center">
       {user && (
         <span className="text-xs text-gray-500">Username: {user.username}</span>
       )}
       <span>Attempts: {attempts}</span>
       {showVictory ? (
-        <span className="text-green-600 animate-pulse">
+        <span className="text-[var(--success)] animate-pulse">
           🎉 You completed the Knight's Tour!
         </span>
       ) : showFailure ? (
-        <span className="text-[var(--primary)] animate-failshake">
+        <span className="text-[var(--error)] animate-failshake">
           No more moves! Try again.
         </span>
       ) : !gameStarted ? (


### PR DESCRIPTION
## Summary
- apply soft pastel palette in `globals.css`
- use Poppins font and update layout
- alternate board square colors and add hover lift
- show success and failure overlays with new highlight animation
- update button and info styles

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8dbb2b548331a7f6f3a3d6f7d4be