### PR TITLE
Improve square visibility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,8 +6,9 @@
   --primary: #C8F0E6;
   --secondary: #E9E5FF;
   --surface: #F4F5F7;
+  /* Unified board colors for consistent appearance */
   --board-light: #F4F5F7;
-  --board-dark: #E8F2FF;
+  --board-dark: #F4F5F7;
   --success: #FFE3C4;
   --error: #FFD8DC;
 }

--- a/app/play/[size]/page.tsx
+++ b/app/play/[size]/page.tsx
@@ -75,7 +75,7 @@ export default function PlayPage() {
         </div>
         <Link
           href="/leaderboard"
-          className="absolute right-6 top-1/2 -translate-y-1/2 bg-[var(--secondary)] text-[var(--background)] font-semibold px-5 py-2 rounded-xl shadow hover:brightness-110 transition text-base sm:text-lg"
+          className="absolute right-6 top-1/2 -translate-y-1/2 bg-[var(--secondary)] text-[var(--foreground)] font-semibold px-5 py-2 rounded-xl shadow hover:brightness-110 transition text-base sm:text-lg"
           style={{ minWidth: 140, textAlign: "center" }}
         >
           🏆 Leaderboard

--- a/components/Square.tsx
+++ b/components/Square.tsx
@@ -64,7 +64,7 @@ export default function Square({
         </span>
       ) : isVisited ? (
 
-        <span className="text-[var(--background)] text-lg font-bold select-none">{moveNum}</span>
+        <span className="text-[var(--foreground)] text-lg font-bold select-none">{moveNum}</span>
 
       ) : null}
     </button>


### PR DESCRIPTION
## Summary
- unify board-light and board-dark colors
- update leaderboard button and square text colors for better contrast

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b973c96848331b173d47895a0dad7