### PR TITLE
Enhance game board styling

### DIFF
--- a/app/play/[size]/page.tsx
+++ b/app/play/[size]/page.tsx
@@ -75,14 +75,22 @@ export default function PlayPage() {
         </div>
         <Link
           href="/leaderboard"
-          className="absolute right-6 top-1/2 -translate-y-1/2 bg-[var(--secondary)] text-[var(--background)] font-semibold px-5 py-2 rounded-xl shadow hover:brightness-110 transition text-base sm:text-lg"
-          style={{ minWidth: 140, textAlign: "center" }}
+          className="absolute right-6 top-1/2 -translate-y-1/2 bg-[var(--secondary)] text-[var(--background)] font-semibold px-5 py-2 rounded-xl shadow hover:brightness-110 transition text-base sm:text-lg hover:scale-[1.04]"
+          style={{
+            minWidth: 140,
+            textAlign: "center",
+            boxShadow:
+              "0 4px 10px rgba(0,0,0,0.1), inset 0 0 4px rgba(255,255,255,0.15)",
+          }}
         >
           🏆 Leaderboard
         </Link>
       </div>
 
-      <div className="flex flex-col items-center bg-white/95 rounded-3xl shadow-2xl p-6 sm:p-12 mt-2 max-w-fit border-[var(--primary)]/20 border-[2.5px]">
+      <div
+        className="flex flex-col items-center bg-white/95 rounded-3xl p-6 sm:p-12 mt-2 max-w-fit border-[var(--primary)]/20 border-[2.5px]"
+        style={{ boxShadow: "0 4px 10px rgba(0,0,0,0.1), inset 0 0 8px rgba(255,255,255,0.1)" }}
+      >
         <GameControls
           boardSize={boardSize}
           undoDisabled={undoDisabled}
@@ -150,6 +158,17 @@ export default function PlayPage() {
           100% { transform: translateY(0) scale(1);}
         }
         .animate-hopknight { animation: hopknight 0.16s;}
+        @keyframes moveglow {
+          0% {
+            box-shadow: 0 0 0 0 var(--primary);
+            opacity: 1;
+          }
+          100% {
+            box-shadow: 0 0 16px 6px rgba(139, 92, 246, 0);
+            opacity: 0;
+          }
+        }
+        .animate-move-glow { animation: moveglow 0.3s ease-out forwards; }
         `}
       </style>
     </main>

--- a/components/Square.tsx
+++ b/components/Square.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useState } from "react";
+
 interface SquareProps {
   isKnight: boolean;
   moveNum: number;
@@ -19,8 +21,18 @@ export default function Square({
   onClick,
   disabled,
 }: SquareProps) {
+  const [highlight, setHighlight] = useState(false);
+
+  useEffect(() => {
+    if (isValidMove) {
+      setHighlight(true);
+      const t = setTimeout(() => setHighlight(false), 300);
+      return () => clearTimeout(t);
+    }
+  }, [isValidMove]);
+
   const squareColor = isKnight
-    ? "bg-[var(--primary)] shadow-2xl"
+    ? "bg-[var(--primary)]"
     : isVisited
     ? "bg-[var(--secondary)]/90"
     : "bg-[var(--surface)]";
@@ -29,14 +41,17 @@ export default function Square({
     <button
       className={`
         relative w-[85px] h-[85px] rounded-xl border border-[var(--primary)]/30 overflow-hidden
-        flex flex-col items-center justify-center transition-all
-        ${isValidMove ? "ring-2 ring-[var(--primary)]/80 z-10" : ""}
+        flex flex-col items-center justify-center transition-transform
+        hover:scale-[1.04]
+        ${highlight ? "animate-move-glow" : ""}
         ${squareColor}
         ${cellEffect}
       `}
       style={{
         transition: "background 0.18s, box-shadow 0.16s, transform 0.18s",
-        boxShadow: isKnight ? "0 8px 36px #8b5cf647" : "",
+        boxShadow: isKnight
+          ? "0 8px 36px #8b5cf647"
+          : "0 4px 10px rgba(0,0,0,0.1), inset 0 0 6px rgba(255,255,255,0.15)",
       }}
       tabIndex={0}
       onClick={onClick}

--- a/components/play/GameBoard.tsx
+++ b/components/play/GameBoard.tsx
@@ -38,13 +38,15 @@ export default function GameBoard({
 }: GameBoardProps) {
   return (
     <div
-      className="relative shadow-2xl rounded-3xl border-[2.5px] border-[var(--primary)]/30 bg-[var(--surface)] flex justify-center items-center"
+      className="relative rounded-3xl border-[2.5px] border-[var(--primary)]/30 bg-[var(--surface)] flex justify-center items-center"
       style={{
         padding: 22,
         margin: 8,
         minWidth: boardSize * (cellSize + 8),
         minHeight: boardSize * (cellSize + 8),
         position: "relative",
+        boxShadow:
+          "0 4px 10px rgba(0,0,0,0.1), inset 0 0 8px rgba(255,255,255,0.1)",
       }}
     >
       <div

--- a/components/play/GameControls.tsx
+++ b/components/play/GameControls.tsx
@@ -29,15 +29,17 @@ export default function GameControls({
   return (
     <div className="flex flex-wrap justify-center gap-3 mb-1">
       <button
-        className="px-4 py-1 rounded-md bg-[var(--primary)] text-white font-semibold hover:brightness-110"
+        className="px-4 py-1 rounded-md bg-[var(--primary)] text-white font-semibold hover:brightness-110 transition-transform hover:scale-[1.04]"
+        style={{ boxShadow: "0 4px 10px rgba(0,0,0,0.1), inset 0 0 4px rgba(255,255,255,0.15)" }}
         onClick={() => router.push("/")}
       >
         Home
       </button>
       <button
-        className={`px-4 py-1 rounded-md bg-[var(--primary)] text-white font-semibold hover:brightness-110 ${
+        className={`px-4 py-1 rounded-md bg-[var(--primary)] text-white font-semibold hover:brightness-110 transition-transform hover:scale-[1.04] ${
           undoDisabled ? "opacity-40 cursor-not-allowed" : ""
         }`}
+        style={{ boxShadow: "0 4px 10px rgba(0,0,0,0.1), inset 0 0 4px rgba(255,255,255,0.15)" }}
         onClick={onUndo}
         disabled={undoDisabled || showingSolution || showVictory || showFailure}
         title="Undo"
@@ -45,9 +47,10 @@ export default function GameControls({
         Undo
       </button>
       <button
-        className={`px-4 py-1 rounded-md bg-[var(--primary)] text-white font-semibold hover:brightness-110 ${
+        className={`px-4 py-1 rounded-md bg-[var(--primary)] text-white font-semibold hover:brightness-110 transition-transform hover:scale-[1.04] ${
           redoDisabled ? "opacity-40 cursor-not-allowed" : ""
         }`}
+        style={{ boxShadow: "0 4px 10px rgba(0,0,0,0.1), inset 0 0 4px rgba(255,255,255,0.15)" }}
         onClick={onRedo}
         disabled={redoDisabled || showingSolution || showVictory || showFailure}
         title="Redo"
@@ -56,7 +59,8 @@ export default function GameControls({
       </button>
       {boardSize === 5 && (
         <button
-          className="px-4 py-1 rounded-md bg-[var(--primary)] text-white font-semibold hover:brightness-110"
+          className="px-4 py-1 rounded-md bg-[var(--primary)] text-white font-semibold hover:brightness-110 transition-transform hover:scale-[1.04]"
+          style={{ boxShadow: "0 4px 10px rgba(0,0,0,0.1), inset 0 0 4px rgba(255,255,255,0.15)" }}
           disabled={showingSolution}
           onClick={onShowSolution}
         >
@@ -64,7 +68,8 @@ export default function GameControls({
         </button>
       )}
       <button
-        className="px-4 py-1 rounded-md bg-[var(--secondary)] text-[var(--background)] font-semibold hover:brightness-110"
+        className="px-4 py-1 rounded-md bg-[var(--secondary)] text-[var(--background)] font-semibold hover:brightness-110 transition-transform hover:scale-[1.04]"
+        style={{ boxShadow: "0 4px 10px rgba(0,0,0,0.1), inset 0 0 4px rgba(255,255,255,0.15)" }}
         onClick={onReset}
       >
         Reset

--- a/components/play/UserNamePrompt.tsx
+++ b/components/play/UserNamePrompt.tsx
@@ -23,7 +23,8 @@ export default function UserNamePrompt({
     <div className="fixed inset-0 z-50 bg-black/60 text-black flex items-center justify-center">
       <form
         onSubmit={handleSubmit}
-        className="bg-white p-6 rounded-lg shadow-xl flex flex-col gap-4"
+        className="bg-white p-6 rounded-lg flex flex-col gap-4"
+        style={{ boxShadow: "0 4px 10px rgba(0,0,0,0.1), inset 0 0 8px rgba(255,255,255,0.1)" }}
       >
         <label className="text-xl font-semibold">Enter your Username</label>
         <input
@@ -34,7 +35,8 @@ export default function UserNamePrompt({
           autoFocus
         />
         <button
-          className="bg-[var(--primary)] text-white py-2 rounded font-semibold hover:brightness-110"
+          className="bg-[var(--primary)] text-white py-2 rounded font-semibold hover:brightness-110 transition-transform hover:scale-[1.04]"
+          style={{ boxShadow: "0 4px 10px rgba(0,0,0,0.1), inset 0 0 4px rgba(255,255,255,0.15)" }}
           disabled={loading}
         >
           {loading ? "Registering..." : "Start Playing"}


### PR DESCRIPTION
## Summary
- add new "move glow" animation for legal move hint
- introduce highlight/hover styling in Square tiles
- style game board container and buttons with subtle shadows and inner glows
- tweak form and leaderboard link for consistent shadowed look

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb1ff2fa483318b06cc83f7af90d9