### PR TITLE
Convert UI to black and white

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,11 +2,12 @@
 
 :root {
 
-  --background: #0f172a;
-  --foreground: #e2e8f0;
-  --primary: #8b5cf6;
-  --secondary: #fbbf24;
-  --surface: #1e293b;
+  /* Monochrome colour scheme */
+  --background: #ffffff; /* page background */
+  --foreground: #000000; /* text */
+  --primary: #000000;   /* accents and headers */
+  --secondary: #ffffff; /* secondary accents */
+  --surface: #f0f0f0;   /* cards and surfaces */
 
 }
 
@@ -19,10 +20,9 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #f8fafc;
-    --surface: #111827;
-
+    --background: #000000;
+    --foreground: #ffffff;
+    --surface: #1a1a1a;
   }
 }
 

--- a/components/Square.tsx
+++ b/components/Square.tsx
@@ -67,7 +67,7 @@ export default function Square({
         <span
           className="text-xl font-bold select-none"
           style={{
-            color: squareColor === "#242424" ? "#f6f6f6" : "#242424",
+            color: squareColor === "#000000" ? "#ffffff" : "#000000",
           }}
         >
           {moveNum}

--- a/components/play/GameBoard.tsx
+++ b/components/play/GameBoard.tsx
@@ -58,9 +58,9 @@ export default function GameBoard({
 
   const boardPx = boardSize * cellSize;
 
-  // Chessboard color palette (modern look)
-  const chessLight = "#f6f6f6"; // almost white
-  const chessDark = "#242424"; // almost black
+  // Chessboard color palette: classic black and white
+  const chessLight = "#ffffff"; // white
+  const chessDark = "#000000"; // black
 
   return (
     <div

--- a/components/play/GameInfo.tsx
+++ b/components/play/GameInfo.tsx
@@ -25,7 +25,7 @@ export default function GameInfo({
       )}
       <span>Attempts: {attempts}</span>
       {showVictory ? (
-        <span className="text-green-600 animate-pulse">
+        <span className="animate-pulse text-[var(--foreground)]">
           🎉 You completed the Knight's Tour!
         </span>
       ) : showFailure ? (


### PR DESCRIPTION
## Summary
- switch global CSS variables to a monochrome scheme
- use pure black and white squares on the game board
- update square text colours for new board shades
- adjust victory message style for grayscale theme

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cedaab1948331a8977fde42f5e5f5