### PR TITLE
Apply monochrome theme and adjust solution animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -32,6 +32,10 @@ body {
   font-family: var(--font-sans), Arial, Helvetica, sans-serif;
 }
 
+button {
+  border: none;
+}
+
 @keyframes knightJump {
   0% { transform: scale(1) translateY(0);}
   25% { transform: scale(1.20) translateY(-22px) rotate(-12deg);}

--- a/components/Square.tsx
+++ b/components/Square.tsx
@@ -42,7 +42,7 @@ export default function Square({
       className={`
         relative
         w-[90px] h-[90px]
-        border-0
+        border-none
         rounded-none
         overflow-hidden
         flex flex-col items-center justify-center

--- a/hooks/useKnightsTour.ts
+++ b/hooks/useKnightsTour.ts
@@ -18,14 +18,11 @@ export const SOLUTIONS: Record<number, number[][]> = {
 };
 
 const CONFETTI_COLORS = [
-  "#8b5cf6",
-  "#fbbf24",
+  "#000000",
+  "#444444",
+  "#888888",
+  "#bbbbbb",
   "#ffffff",
-  "#4f46e5",
-  "#f472b6",
-  "#22d3ee",
-  "#4ade80",
-  "#64748b",
 ];
 
 function getKnightMoves(pos: Position, boardSize: number): Position[] {
@@ -212,7 +209,22 @@ export function useKnightsTour(boardSize: number, user: User | null) {
   function handleShowSolution() {
     setShowingSolution(true);
     setSolutionStep(1);
-    setKnightPos(null);
+    if (boardSize === 5) {
+      // Position knight on the first move of the predefined solution
+      let start: Position | null = null;
+      for (let i = 0; i < boardSize; i++) {
+        for (let j = 0; j < boardSize; j++) {
+          if (SOLUTIONS[5][i][j] === 1) {
+            start = { row: i, col: j };
+            break;
+          }
+        }
+        if (start) break;
+      }
+      setKnightPos(start);
+    } else {
+      setKnightPos(null);
+    }
     setVisited(Array.from({ length: boardSize }, () => Array(boardSize).fill(0)));
     setGameStarted(false);
     setMoveCount(0);


### PR DESCRIPTION
## Summary
- remove button borders for a borderless grid look
- swap square style to `border-none`
- use greyscale colors for confetti
- start the solution sequence with the knight on the first square

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cfa269c988331ae951d827ae357d8