### PR TITLE
Improve board highlight and animations

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -66,6 +66,15 @@ button {
   animation: pulseRingOnce 1.5s cubic-bezier(.66,0,.34,1) 1;
 }
 
+@keyframes pulseRing {
+  0% { box-shadow: 0 0 0 0 var(--secondary); }
+  70% { box-shadow: 0 0 0 14px rgba(251,191,36,0); }
+  100% { box-shadow: 0 0 0 0 rgba(251,191,36,0);}
+}
+.animate-pulse-ring {
+  animation: pulseRing 1.5s cubic-bezier(.66,0,.34,1) infinite;
+}
+
 @keyframes cellCurrent {
   0% { box-shadow: 0 0 0 0 var(--primary);}
   100% { box-shadow: 0 0 24px 8px var(--primary);}

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -42,7 +42,7 @@ export default function LeaderboardPage() {
       </div>
 
       {/* ─── Table ───────────────────────────────────────────────────── */}
-      <div className="bg-white/90 text-black rounded-2xl border border-[color:var(--primary)/0.2] shadow-lg p-8 w-full max-w-2xl">
+      <div className="bg-[var(--surface)] text-[var(--foreground)] rounded-2xl border border-[var(--primary)/0.2] shadow-lg p-8 w-full max-w-2xl">
         <table className="w-full text-lg">
           <thead>
             <tr className="text-left border-b">
@@ -71,7 +71,7 @@ export default function LeaderboardPage() {
             )}
             {!loading &&
               records.map((rec, idx) => (
-                <tr key={rec.id} className="border-b hover:bg-gray-50">
+                <tr key={rec.id} className="border-b hover:bg-[var(--surface)]">
                   <td className="py-2">{idx + 1}</td>
                   <td className="py-2">{rec.name}</td>
                   <td className="py-2">

--- a/components/Square.tsx
+++ b/components/Square.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { useEffect, useState } from "react";
 
 interface SquareProps {
   isKnight: boolean;
@@ -24,18 +23,6 @@ export default function Square({
   isCurrent,
   squareColor,
 }: SquareProps) {
-  // Handle one-time pulse for destinations
-  const [pulseOnce, setPulseOnce] = useState(false);
-
-  useEffect(() => {
-    if (isValidMove) {
-      setPulseOnce(true);
-      const t = setTimeout(() => setPulseOnce(false), 700);
-      return () => clearTimeout(t);
-    } else {
-      setPulseOnce(false);
-    }
-  }, [isValidMove]);
 
   return (
     <button
@@ -48,7 +35,7 @@ export default function Square({
         flex flex-col items-center justify-center
         transition-transform
         hover:scale-[1.04]
-        ${pulseOnce && !isKnight ? "animate-pulse-ring-once" : ""}
+        ${isValidMove && !isKnight ? "animate-pulse-ring" : ""}
         ${cellEffect}
       `}
       style={{
@@ -67,7 +54,10 @@ export default function Square({
         <span
           className="text-xl font-bold select-none"
           style={{
-            color: squareColor === "#000000" ? "#ffffff" : "#000000",
+            color:
+              squareColor === "var(--foreground)"
+                ? "var(--background)"
+                : "var(--foreground)",
           }}
         >
           {moveNum}

--- a/components/play/GameBoard.tsx
+++ b/components/play/GameBoard.tsx
@@ -58,9 +58,9 @@ export default function GameBoard({
 
   const boardPx = boardSize * cellSize;
 
-  // Chessboard color palette: classic black and white
-  const chessLight = "#ffffff"; // white
-  const chessDark = "#000000"; // black
+  // Chessboard colors aligned with app theme
+  const chessLight = "var(--background)";
+  const chessDark = "var(--foreground)";
 
   return (
     <div

--- a/hooks/useKnightsTour.ts
+++ b/hooks/useKnightsTour.ts
@@ -61,6 +61,7 @@ export function useKnightsTour(boardSize: number, user: User | null) {
 
   const [showVictory, setShowVictory] = useState(false);
   const [showFailure, setShowFailure] = useState(false);
+  const [gameEnded, setGameEnded] = useState(false);
 
   const [knightAnim, setKnightAnim] = useState<{ row: number; col: number } | null>(null);
   const animTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -191,7 +192,8 @@ export function useKnightsTour(boardSize: number, user: User | null) {
     setKnightAnim(null);
     setConfetti(false);
     setStartTime(null);
-    setRunSaved(false); 
+    setRunSaved(false);
+    setGameEnded(false);
   }
 
   useEffect(() => {
@@ -272,7 +274,8 @@ export function useKnightsTour(boardSize: number, user: User | null) {
   const isStuck = gameStarted && !hasWon && validMoves.length === 0;
 
   useEffect(() => {
-    if ((hasWon && gameStarted && !showVictory) || (isStuck && !showFailure)) {
+    if (!gameEnded && ((hasWon && gameStarted) || isStuck)) {
+      setGameEnded(true);
       setConfetti(true);
       const particles: ConfettiParticle[] = Array.from({ length: 32 }).map((_, i) => ({
         left: 10 + i * 2.6 + (i % 3),
@@ -289,7 +292,7 @@ export function useKnightsTour(boardSize: number, user: User | null) {
         setShowVictory(true);
         if (!runSaved) {
           saveRun();
-          setRunSaved(true); // <--- prevents multiple saves!
+          setRunSaved(true);
         }
         setTimeout(() => setShowVictory(false), 1500);
       }
@@ -299,7 +302,7 @@ export function useKnightsTour(boardSize: number, user: User | null) {
       }
       setTimeout(() => setConfetti(false), 1400);
     }
-  }, [hasWon, gameStarted, showVictory, isStuck, showFailure, runSaved, saveRun]);
+  }, [hasWon, gameStarted, isStuck, runSaved, saveRun, gameEnded]);
 
   // --- When boardSize/user changes, load current attempts ---
   useEffect(() => {


### PR DESCRIPTION
## Summary
- keep valid moves highlighted continuously
- align chessboard colors with app theme variables
- prevent repeated win/fail animations
- use theme colors on leaderboard table
- add CSS animation for continuous pulse

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d00545438833197ca45821640bf42