### PR TITLE
Match explorer theme and remove knight from solution

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -66,6 +66,15 @@ button {
   animation: pulseRingOnce 1.5s cubic-bezier(.66,0,.34,1) 1;
 }
 
+@keyframes pulseRing {
+  0% { box-shadow: 0 0 0 0 var(--secondary); }
+  70% { box-shadow: 0 0 0 14px rgba(251,191,36,0); }
+  100% { box-shadow: 0 0 0 0 rgba(251,191,36,0);}
+}
+.animate-pulse-ring {
+  animation: pulseRing 1.5s cubic-bezier(.66,0,.34,1) infinite;
+}
+
 @keyframes cellCurrent {
   0% { box-shadow: 0 0 0 0 var(--primary);}
   100% { box-shadow: 0 0 24px 8px var(--primary);}

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -42,7 +42,7 @@ export default function LeaderboardPage() {
       </div>
 
       {/* ─── Table ───────────────────────────────────────────────────── */}
-      <div className="bg-white/90 text-black rounded-2xl border border-[color:var(--primary)/0.2] shadow-lg p-8 w-full max-w-2xl">
+      <div className="bg-[var(--surface)] text-[var(--foreground)] rounded-2xl border border-[var(--primary)/0.2] shadow-lg p-8 w-full max-w-2xl">
         <table className="w-full text-lg">
           <thead>
             <tr className="text-left border-b">
@@ -71,7 +71,7 @@ export default function LeaderboardPage() {
             )}
             {!loading &&
               records.map((rec, idx) => (
-                <tr key={rec.id} className="border-b hover:bg-gray-50">
+                <tr key={rec.id} className="border-b hover:bg-[var(--surface)]">
                   <td className="py-2">{idx + 1}</td>
                   <td className="py-2">{rec.name}</td>
                   <td className="py-2">

--- a/components/AnimatedKnight.tsx
+++ b/components/AnimatedKnight.tsx
@@ -34,7 +34,9 @@ export function AnimatedKnight({
       >
         <span
           className="text-6xl drop-shadow-2xl leading-none"
-          style={{ color: (row + col) % 2 === 0 ? "#000000" : "#ffffff" }}
+          style={{
+            color: (row + col) % 2 === 0 ? "var(--foreground)" : "var(--background)"
+          }}
         >
           ♞
         </span>

--- a/components/KnightExplorer.tsx
+++ b/components/KnightExplorer.tsx
@@ -17,8 +17,8 @@ const OFFSETS: [number, number][] = [
 ];
 
 // CHESS COLORS
-const CHESS_LIGHT = "#fff";
-const CHESS_DARK = "#000";
+const CHESS_LIGHT = "var(--background)";
+const CHESS_DARK = "var(--foreground)";
 
 // Timings
 const PREVIEW_MS = 1800;
@@ -149,15 +149,15 @@ export default function TutorialKnightMoves() {
     <div
       className="flex flex-col items-center gap-4 p-5 rounded-2xl shadow-xl select-none min-w-[330px]"
       style={{
-        background: "#222", // or keep your theme color
-        color: "#fff",
-        border: `1.5px solid #b5886390`,
-        boxShadow: `0 4px 16px #b5886360`,
+        background: "var(--surface)",
+        color: "var(--foreground)",
+        border: `1.5px solid var(--primary)`,
+        boxShadow: `0 4px 16px rgba(0,0,0,0.2)`,
       }}
     >
       <div
         className="text-base font-semibold mb-2"
-        style={{ color: "#b58863" }}
+        style={{ color: "var(--primary)" }}
       >
         How does the Knight move?
       </div>
@@ -167,7 +167,7 @@ export default function TutorialKnightMoves() {
         style={{
           width: CELL * GRID,
           height: CELL * GRID,
-          border: `2.5px solid #b5886370`,
+          border: `2.5px solid var(--primary)`,
         }}
       >
         {/* squares */}
@@ -331,11 +331,11 @@ export default function TutorialKnightMoves() {
         className={`px-4 py-2 rounded-lg font-semibold mt-2 shadow transition ${
           animating && !finished
             ? "bg-gray-400 text-white opacity-60 cursor-not-allowed"
-            : "bg-[#8b5cf6] text-white hover:bg-[#fbbf24] hover:text-[#0f172a]"
+            : "bg-[var(--secondary)] text-[var(--background)] hover:brightness-110"
         }`}
         style={{
           minWidth: 100,
-          border: `1.5px solid #b5886355`,
+          border: `1.5px solid var(--primary)`,
         }}
       >
         Replay

--- a/components/Square.tsx
+++ b/components/Square.tsx
@@ -1,5 +1,4 @@
 "use client";
-import { useEffect, useState } from "react";
 
 interface SquareProps {
   isKnight: boolean;
@@ -24,18 +23,6 @@ export default function Square({
   isCurrent,
   squareColor,
 }: SquareProps) {
-  // Handle one-time pulse for destinations
-  const [pulseOnce, setPulseOnce] = useState(false);
-
-  useEffect(() => {
-    if (isValidMove) {
-      setPulseOnce(true);
-      const t = setTimeout(() => setPulseOnce(false), 700);
-      return () => clearTimeout(t);
-    } else {
-      setPulseOnce(false);
-    }
-  }, [isValidMove]);
 
   return (
     <button
@@ -48,7 +35,7 @@ export default function Square({
         flex flex-col items-center justify-center
         transition-transform
         hover:scale-[1.04]
-        ${pulseOnce && !isKnight ? "animate-pulse-ring-once" : ""}
+        ${isValidMove && !isKnight ? "animate-pulse-ring" : ""}
         ${cellEffect}
       `}
       style={{
@@ -67,7 +54,10 @@ export default function Square({
         <span
           className="text-xl font-bold select-none"
           style={{
-            color: squareColor === "#000000" ? "#ffffff" : "#000000",
+            color:
+              squareColor === "var(--foreground)"
+                ? "var(--background)"
+                : "var(--foreground)",
           }}
         >
           {moveNum}

--- a/components/play/GameBoard.tsx
+++ b/components/play/GameBoard.tsx
@@ -58,9 +58,9 @@ export default function GameBoard({
 
   const boardPx = boardSize * cellSize;
 
-  // Chessboard color palette: classic black and white
-  const chessLight = "#ffffff"; // white
-  const chessDark = "#000000"; // black
+  // Chessboard colors aligned with app theme
+  const chessLight = "var(--background)";
+  const chessDark = "var(--foreground)";
 
   return (
     <div
@@ -98,7 +98,7 @@ export default function GameBoard({
             } else {
               moveNum = visited[row][col];
               isVisited = moveNum > 0;
-              isKnight = knightPos?.row === row && knightPos?.col === col;
+              isKnight = false;
             }
             const isValidMove =
               !showingSolution &&
@@ -112,7 +112,7 @@ export default function GameBoard({
             return (
               <Square
                 key={`${row}-${col}`}
-                isKnight={knightPos?.row === row && knightPos?.col === col}
+                isKnight={!showingSolution && knightPos?.row === row && knightPos?.col === col}
                 moveNum={moveNum}
                 isVisited={isVisited}
                 isValidMove={isValidMove}
@@ -123,7 +123,7 @@ export default function GameBoard({
                   showFailure ||
                   showingSolution
                 }
-                isCurrent={knightPos?.row === row && knightPos?.col === col}
+                isCurrent={!showingSolution && knightPos?.row === row && knightPos?.col === col}
                 cellEffect={""}
                 squareColor={chessSquare}
               />
@@ -133,7 +133,7 @@ export default function GameBoard({
         {confetti && <ConfettiBurst particles={confettiParticles} />}
       </div>
       {/* Animated Knight on top */}
-      {knightPos && (
+      {!showingSolution && knightPos && (
         <AnimatedKnight
           row={knightPos.row}
           col={knightPos.col}

--- a/hooks/useKnightsTour.ts
+++ b/hooks/useKnightsTour.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase";
 import type { ConfettiParticle } from "@/components/ConfettiBurst";
 import type { Position } from "@/components/play/GameBoard";
@@ -61,9 +61,9 @@ export function useKnightsTour(boardSize: number, user: User | null) {
 
   const [showVictory, setShowVictory] = useState(false);
   const [showFailure, setShowFailure] = useState(false);
+  const [gameEnded, setGameEnded] = useState(false);
 
   const [knightAnim, setKnightAnim] = useState<{ row: number; col: number } | null>(null);
-  const animTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [confetti, setConfetti] = useState(false);
   const [confettiParticles, setConfettiParticles] = useState<ConfettiParticle[]>([]);
@@ -191,7 +191,8 @@ export function useKnightsTour(boardSize: number, user: User | null) {
     setKnightAnim(null);
     setConfetti(false);
     setStartTime(null);
-    setRunSaved(false); 
+    setRunSaved(false);
+    setGameEnded(false);
   }
 
   useEffect(() => {
@@ -209,22 +210,7 @@ export function useKnightsTour(boardSize: number, user: User | null) {
   function handleShowSolution() {
     setShowingSolution(true);
     setSolutionStep(1);
-    if (boardSize === 5) {
-      // Position knight on the first move of the predefined solution
-      let start: Position | null = null;
-      for (let i = 0; i < boardSize; i++) {
-        for (let j = 0; j < boardSize; j++) {
-          if (SOLUTIONS[5][i][j] === 1) {
-            start = { row: i, col: j };
-            break;
-          }
-        }
-        if (start) break;
-      }
-      setKnightPos(start);
-    } else {
-      setKnightPos(null);
-    }
+    setKnightPos(null);
     setVisited(Array.from({ length: boardSize }, () => Array(boardSize).fill(0)));
     setGameStarted(false);
     setMoveCount(0);
@@ -237,30 +223,6 @@ export function useKnightsTour(boardSize: number, user: User | null) {
     setStartTime(null);
   }
 
-  // --- Animate solution knight ---
-  useEffect(() => {
-    if (
-      showingSolution &&
-      boardSize === 5 &&
-      solutionStep > 1 &&
-      solutionStep <= 25
-    ) {
-      let nextKnight: Position | null = null;
-      for (let i = 0; i < boardSize; i++) {
-        for (let j = 0; j < boardSize; j++) {
-          if (SOLUTIONS[5][i][j] === solutionStep) {
-            nextKnight = { row: i, col: j };
-          }
-        }
-      }
-      setKnightAnim(knightPos);
-      if (animTimeout.current) clearTimeout(animTimeout.current);
-      animTimeout.current = setTimeout(() => {
-        setKnightPos(nextKnight);
-      }, 100);
-    }
-  }, [showingSolution, solutionStep, boardSize]);
-
   // --- Confetti and win/fail animations ---
   const hasWon = visited.flat().every((num) => num > 0);
   const validMoves: Position[] =
@@ -272,7 +234,8 @@ export function useKnightsTour(boardSize: number, user: User | null) {
   const isStuck = gameStarted && !hasWon && validMoves.length === 0;
 
   useEffect(() => {
-    if ((hasWon && gameStarted && !showVictory) || (isStuck && !showFailure)) {
+    if (!gameEnded && ((hasWon && gameStarted) || isStuck)) {
+      setGameEnded(true);
       setConfetti(true);
       const particles: ConfettiParticle[] = Array.from({ length: 32 }).map((_, i) => ({
         left: 10 + i * 2.6 + (i % 3),
@@ -289,7 +252,7 @@ export function useKnightsTour(boardSize: number, user: User | null) {
         setShowVictory(true);
         if (!runSaved) {
           saveRun();
-          setRunSaved(true); // <--- prevents multiple saves!
+          setRunSaved(true);
         }
         setTimeout(() => setShowVictory(false), 1500);
       }
@@ -299,7 +262,7 @@ export function useKnightsTour(boardSize: number, user: User | null) {
       }
       setTimeout(() => setConfetti(false), 1400);
     }
-  }, [hasWon, gameStarted, showVictory, isStuck, showFailure, runSaved, saveRun]);
+  }, [hasWon, gameStarted, isStuck, runSaved, saveRun, gameEnded]);
 
   // --- When boardSize/user changes, load current attempts ---
   useEffect(() => {


### PR DESCRIPTION
## Summary
- keep the knight hidden while the solution plays back
- theme the Knight Explorer with CSS variables

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d00545438833197ca45821640bf42