### PR TITLE
Improve responsiveness and soften theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,11 +2,12 @@
 
 :root {
   /* Classic Chess Theme */
-  --background: #ffffff; /* page background - white */
-  --foreground: #000000; /* text and pieces - black */
-  --primary: #000000; /* primary actions, headers - black */
-  --secondary: #888888; /* secondary accents, borders - grey */
-  --surface: #f0f0f0; /* cards and surfaces - light grey */
+  /* Softer light theme using subtle shades of white and black */
+  --background: #fdfdfd; /* page background */
+  --foreground: #111111; /* primary text */
+  --primary: #111111; /* headers and accents */
+  --secondary: #666666; /* borders and subtle text */
+  --surface: #f5f5f5; /* cards and panels */
 
   /* Specific colors for success and error messages */
   --success-color: #10B981; /* Still green for victory, can be changed if needed */
@@ -33,10 +34,12 @@
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #000000;
-    --foreground: #f5f5f5;
+    /* Dark theme with softer contrast */
+    --background: #111111;
+    --foreground: #e5e5e5;
     --primary: #ffffff;
-    --surface: #1c1c1c;
+    --surface: #1e1e1e;
+    --secondary: #777777;
 
     /* Dark mode specific colors for success and error messages */
     --success-color: #34D399;

--- a/app/play/[size]/page.tsx
+++ b/app/play/[size]/page.tsx
@@ -31,7 +31,19 @@ export default function PlayPage() {
 
   const [rows, cols] = params.size.split("x").map((n) => parseInt(n, 10));
   const boardSize = rows;
-  const CELL_SIZE = 85;
+
+  const [cellSize, setCellSize] = useState(85);
+  useEffect(() => {
+    function updateSize() {
+      const w = window.innerWidth;
+      if (w < 640) setCellSize(40);
+      else if (w < 1024) setCellSize(70);
+      else setCellSize(100);
+    }
+    updateSize();
+    window.addEventListener("resize", updateSize);
+    return () => window.removeEventListener("resize", updateSize);
+  }, []);
 
   const {
     knightPos,
@@ -75,7 +87,7 @@ export default function PlayPage() {
         </div>
       </div>
 
-      <div className="flex flex-row items-start gap-10">
+      <div className="flex flex-col lg:flex-row items-start gap-6 sm:gap-10">
         {/* Left: Game board and controls */}
         <div
           className="flex flex-col items-center bg-white/95 rounded-3xl p-6 sm:p-12 mt-2 max-w-fit border-[var(--foreground)]/20 border-[2.5px]"
@@ -98,7 +110,7 @@ export default function PlayPage() {
           />
           <GameBoard
             boardSize={boardSize}
-            cellSize={CELL_SIZE}
+            cellSize={cellSize}
             visited={visited}
             knightPos={knightPos}
             showingSolution={showingSolution}

--- a/components/play/GameBoard.tsx
+++ b/components/play/GameBoard.tsx
@@ -68,7 +68,7 @@ export default function GameBoard({
 
   return (
     <div
-      className="relative rounded-3xl border-[2.5px] border-[var(--primary)]/30 flex flex-col items-center justify-center mx-8"
+      className="relative rounded-3xl border-[2.5px] border-[var(--primary)]/30 flex flex-col items-center justify-center mx-4 sm:mx-8"
       style={{
         padding: 30,
         margin: 20,


### PR DESCRIPTION
## Summary
- soften theme colors using lighter black/white shades
- calculate board cell size based on viewport width
- adjust game layout for mobile

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68627777a2408331894190d8f32af9e1